### PR TITLE
airflow logs written in a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,8 @@ RUN set -ex \
 
 COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
-
-RUN chown -R airflow: ${AIRFLOW_HOME}
+RUN mkdir ${AIRFLOW_HOME}/logs && chown -R airflow: ${AIRFLOW_HOME}
+VOLUME ${AIRFLOW_HOME}/logs/
 
 EXPOSE 8080 5555 8793
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ I had done following things up to now:
 
 * Fix [issue-254:Sequential Executor bug](https://github.com/puckel/docker-airflow/issues/254)
 * Add SQL Alchemy environment variable from [PR-253](https://github.com/puckel/docker-airflow/pull/253)
+* Add [PR-284:Add logs volumn](https://github.com/puckel/docker-airflow/pull/284)
 
 ---
 


### PR DESCRIPTION
making log directory to a volume prevents diff creation by docker.

from https://github.com/puckel/docker-airflow/pull/284