### PR TITLE
Fix Sequential Executor without start scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
 # docker-airflow
+
+## What I do on this repo
+
+This repo is base on nearly not maintenance repo [puckel/docker-airflow](https://github.com/puckel/docker-airflow), and I maintain it when someone find bug in source repo.
+
+This repo have **TWO** main branch, **master** and **custom**. master is downstream of source repo and custom is production environment of myself.
+
+I had done following things up to now:
+
+* Fix [issue-254:Sequential Executor bug](https://github.com/puckel/docker-airflow/issues/254)
+
+---
+
 [![CircleCI](https://circleci.com/gh/puckel/docker-airflow/tree/master.svg?style=svg)](https://circleci.com/gh/puckel/docker-airflow/tree/master)
 [![Docker Build Status](https://img.shields.io/docker/build/puckel/docker-airflow.svg)]()
 

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -70,8 +70,8 @@ fi
 case "$1" in
   webserver)
     airflow initdb
-    if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
-      # With the "Local" executor it should all run in one container.
+    if [ "$AIRFLOW__CORE__EXECUTOR" = "SequentialExecutor" ] || [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
+      # With the "Local" or "Sequential" executor it should all run in one container.
       airflow scheduler &
     fi
     exec airflow webserver


### PR DESCRIPTION
Fix https://github.com/puckel/docker-airflow/issues/254
In readme run `docker run -d -p 8080:8080 puckel/docker-airflow webserver`
will not start scheduler
this PR fix it

From https://github.com/puckel/docker-airflow/pull/314

