### PR TITLE
Fix flower redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis>=2.10.5,<3' \
-    && pip3 install "tornado>=4.2.0,<6.0.0" \
+    && pip install "tornado>=4.2.0,<6.0.0" \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis>=2.10.5,<3' \
+    && pip3 install "tornado>=4.2.0,<6.0.0" \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
-    && pip install 'redis>=2.10.5,<3' \
+    && pip install 'redis>=3.2' \
     && pip install "tornado>=4.2.0,<6.0.0" \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN set -ex \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
-    && pip install 'redis>=3.2' \
+    && pip install 'redis~=3.2' \
     && pip install "tornado>=4.2.0,<6.0.0" \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ I had done following things up to now:
 * Fix [issue-254:Sequential Executor bug](https://github.com/puckel/docker-airflow/issues/254)
 * Add SQL Alchemy environment variable from [PR-253](https://github.com/puckel/docker-airflow/pull/253)
 * Add [PR-284:Add logs volumn](https://github.com/puckel/docker-airflow/pull/284)
+* Add [PR-324:Fix tornado version compatibility issue](https://github.com/puckel/docker-airflow/pull/324)
 
 ---
 


### PR DESCRIPTION
Fetch from https://github.com/puckel/docker-airflow/pull/324#issue-257768430

It looks like the new version of tornado drops a function imported by flower (tornado.web.asynchronous). The flower project has fixed the issue in the [master branch](https://github.com/mher/flower/blob/master/requirements/default.txt), but haven't tagged a release with the fix and, since they haven't released since 2017, it might be a while before they do. Note that Astronomer had to make a [similar fix](https://github.com/astronomer/astronomer/commit/b4c66b10cd499565804df74e6bde5fd4349f00ff).

Yes, bumping the redis version (I tested with redis~=3.2) works for me.
It seems like a similar change was introduced to Airflow yesterday: https://github.com/apache/airflow/commit/02300551905c47f60d65b764e364f77fdb2fb3f7